### PR TITLE
Reduced number of allocations and minor algorithm changes

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -75,7 +75,7 @@ class ImageFitness
                                         "ubyte", 8, "b",
                                         "ubyte", 6, "x",
                                         "ubyte", 6, "y",
-                                        "ubyte", 5, "radius")());
+                                        "ubyte", 6, "radius")());
                 Circle shape;
                 shape.color = CircleColor(r, g, b, 255);
                 shape.x = x;
@@ -171,8 +171,8 @@ void draw()
     auto shapeConvertor = (BitArray genom) =>
     {
     };
-    ImageFitness fitness = new ImageFitness("/home/martin/IdeaProjects/GeneticAlgorithm/mona.jpeg");
-    const uint NUMBER_OF_CIRCLES = 250;
+    ImageFitness fitness = new ImageFitness("mona.jpeg");
+    const uint NUMBER_OF_CIRCLES = 500;
     geneticAlgorithm!(fitness, shapeConvertor)((3 * 8 + 2 * 6 + 5) * NUMBER_OF_CIRCLES, 0.0, 50, 0.99);
 }
 

--- a/source/genetic.d
+++ b/source/genetic.d
@@ -38,6 +38,7 @@ Individual!fitness rouletteSelection(alias fitness)(Individual!fitness[] populat
 Individual!fitness[] evolvePopulation(alias fitness)(Individual!fitness[] population,float mutation)
 {
     Individual!fitness[] newPopulation;
+    newPopulation.reserve(population.length);
     newPopulation ~= population.getFittest;
     foreach(i; 1..population.length)
     {
@@ -53,7 +54,8 @@ Individual!fitness geneticAlgorithm(alias fitness, alias print)(size_t genomSize
 {
     import std.stdio: writeln;
     Individual!fitness[] current;
-    foreach(i; 1..populationSize)
+    current.reserve(populationSize);
+    foreach(i; 0..populationSize)
     {
         current ~= new Individual!fitness(genomSize);
     }

--- a/source/individual.d
+++ b/source/individual.d
@@ -4,14 +4,19 @@ import std.bitmanip;
 import std.random;
 import std.datetime;
 
-
 class Individual(alias fitnessFn)
 {
     private
     {
-        Mt19937 gen;
         BitArray representation;
         double calculatedFitness;
+        static Mt19937 gen;
+    }
+
+    static this()
+    {
+        auto ct = Clock.currTime();
+        gen.seed(cast(uint)(ct.toUnixTime()));
     }
 
     this(BitArray array, bool recalculateFitness = true)
@@ -19,8 +24,6 @@ class Individual(alias fitnessFn)
         representation = array;
         if(recalculateFitness)
             calculatedFitness = fitnessFn(array);
-        auto ct = Clock.currTime();
-        gen.seed(cast(uint)(ct.toUnixTime()));
     }
 
     this(size_t size)
@@ -39,7 +42,7 @@ class Individual(alias fitnessFn)
         {
             if(mutationRate < uniform01(gen))
             {
-                newRepresentation[i] = uniform(0, 2, gen) == 0;
+                newRepresentation[i] = !newRepresentation[i];
             }
         }
         assert(newRepresentation.length() == representation.length());
@@ -50,10 +53,10 @@ class Individual(alias fitnessFn)
     Individual crossover(Individual individual)
     {
         size_t gate = individual.representation.length / 2;
-        bool[] bitArr;
+        bool[] bitArr = new bool[individual.representation.length()];
         foreach(i; 0 .. representation.length)
         {
-            bitArr ~= i <= gate ? representation[i] : individual.representation[i];
+            bitArr[i] = i <= gate ? representation[i] : individual.representation[i];
         }
         assert(bitArr.length == representation.length());
         Individual!fitnessFn newIndividual = new Individual!fitnessFn(BitArray(bitArr), false);


### PR DESCRIPTION
This change speeds up algorithm by reducing number of allocations that are required. Before we had something like this
```D
Foo[] arr;
foreach(i; 0..A_LOT)
{
     arr ~= new Foo();
}
```
This is expansive because we need to do this:
- Allocate new array that is larger
- Copy all elements from arr to that array and insert new element after that
Since in most cases we know how large array we need we can reserve enough space in advanced so there is only one allocation performed.

I also made it so we user one Mersenne twister is used by all individuals. This will hopefully get us better random numbers and also speed things up little.

Lastly I changed how mutation works. In previous versions we generated random bit now we negate the bit. This is better because mutation is guaranteed. 