### PR TITLE
Windows support

### DIFF
--- a/source/opt.d
+++ b/source/opt.d
@@ -8,8 +8,8 @@ struct Options
 {
     bool forever;
     ShapeType type = ShapeType.rectangle;
-    ulong maxEpoch = 10_000;
-    ulong shapeCount = 100;
+    size_t maxEpoch = 10_000;
+    size_t shapeCount = 100;
     float mutation = 0.001;
     string input;
 }


### PR DESCRIPTION
Modifikace Options tak, aby datové typy jednotlivých položek seděly s typy funkce ```geneticAlgorithm```. Je to především díky tomu, že na windows se to bez této modifikace nedá kompilovat